### PR TITLE
MBTI 결과 저장

### DIFF
--- a/src/db/models/mbtiModel.js
+++ b/src/db/models/mbtiModel.js
@@ -31,6 +31,7 @@ class MbtiModel {
   create(mbti) {
     return Mbti.create(mbti).then((doc) => doc.toObject());
   }
+
   // 특정 id를 _id로 갖고 있는 MBTI document를 toUpdate 객체의 내용으로 덮어 씌운다(overwrite).
   // 덮어 씌우는 것이기 때문에 잘못된 값이 의도치 않게 들어가면 문제가 발생할 수 있다.
   update(type) {
@@ -38,9 +39,7 @@ class MbtiModel {
       { type },
       { $inc: { count: 1 } },
       {
-        runValidators: true, // schema 체크(업데이트 될 데이터에 대한 검증)를 진행한다.
-        new: true, // 업데이트 후의 document를 리턴받도록 한다.
-        upsert: true // upsert 옵션을 사용하여 문서가 없으면 새로 생성
+        new: true // 업데이트 후의 document를 리턴받도록 한다.
       }
     ).lean(); // lean을 사용하여 POJO 객체로 바꿔준다.
     return updatedMbti;

--- a/src/routers/mbtiRouter.js
+++ b/src/routers/mbtiRouter.js
@@ -23,14 +23,10 @@ mbtiRouter.post(
 );
 // Mbti 수정
 mbtiRouter.patch(
-  '/:id',
+  '/:type',
   asyncHandler(async (req, res, next) => {
-    const { id } = req.params;
-    const { title, content } = req.body;
-    return await mbtiService.updateMbti(id, {
-      title,
-      content
-    });
+    const { type } = req.params;
+    return await mbtiService.updateMbti(type);
   })
 );
 

--- a/src/services/mbtiService.js
+++ b/src/services/mbtiService.js
@@ -12,8 +12,8 @@ class MbtiService {
     const fits = await this.fitModel.findByType(mbti.type);
     return this.mbtiModel.create({ ...mbti, fit: fits });
   }
-  updateMbti(id, mbti) {
-    return this.mbtiModel.update(id, mbti);
+  updateMbti(mbti) {
+    return this.mbtiModel.update(mbti);
   }
 }
 


### PR DESCRIPTION
### 참조
- MBTI-Inside/todo#5

### 주요 사항
- MBTI 검사 결과를 저장할 때, 클라이언트단에서 계산을 마친 후 MBTI 검사유형만을 매개변수로 전달하게 될 것.
- 따라서 MBTI 유형만 전달받아 해당 유형의 통계 수를 증가시켜주기만 하면 됨.
- 검사 결과를 저장하지 않기 때문에, 로직이 간단해졌음.